### PR TITLE
replace get started tab content w/ a getting started landing page

### DIFF
--- a/src/App.recoil.ts
+++ b/src/App.recoil.ts
@@ -29,3 +29,14 @@ export const activeTabState = atom<string>({
   key: 'appTabsActiveTab',
   default: '0'
 })
+
+export type MainSizeState = {
+  sized: boolean;
+  rect?: DOMRectReadOnly;
+}
+export const mainSizeAtom = atom<MainSizeState>({
+  key: 'appMainSize',
+  default: {
+    sized: false,
+  }
+});

--- a/src/components/GettingStarted/GettingStarted.css
+++ b/src/components/GettingStarted/GettingStarted.css
@@ -1,0 +1,21 @@
+.cover {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+}
+
+.cover > * {
+  margin-block: 1rem;
+}
+
+.cover > :first-child:not(.hero) {
+  margin-block-start: 0;
+}
+
+.cover > :last-child:not(.hero) {
+  margin-block-end: 0;
+}
+
+.cover > .hero {
+  margin-block: auto;
+}

--- a/src/components/GettingStarted/GettingStarted.tsx
+++ b/src/components/GettingStarted/GettingStarted.tsx
@@ -5,10 +5,10 @@ import './GettingStarted.css';
 import NewTabButton from "../NewTabButton/NewTabButton";
 import {TabType} from "../TabIcon/TabIcon";
 import {Nav, Navbar} from "react-bootstrap";
+import NewDocTabButton from "../NewTabButton/NewDocTabButton";
 
 const GettingStarted = () => {
   const mainSizeState = useRecoilValue(mainSizeAtom);
-  console.log('mainSizeState.rect!.height', mainSizeState.rect!.height);
 
   return (
     <div className='cover' style={{
@@ -30,13 +30,13 @@ const GettingStarted = () => {
           <Nav className={'flex-column'}>
             <Navbar.Brand><strong>Learn</strong></Navbar.Brand>
             <Nav.Item>
-              <NewTabButton type={TabType.Docs} text={'Overview'} style={{padding: 0}}/>
+              <NewDocTabButton docId={'overview'} text={'Overview'} style={{padding: 0}}/>
             </Nav.Item>
             <Nav.Item>
-              <NewTabButton type={TabType.Docs} text={'Basic Usage'} style={{padding: 0}}/>
+              <NewDocTabButton docId={'basic-usage'} text={'Basic Usage'} style={{padding: 0}}/>
             </Nav.Item>
             <Nav.Item>
-              <NewTabButton type={TabType.Docs} text={'Advanced Usage'} style={{padding: 0}}/>
+              <NewDocTabButton docId={'advanced-usage'} text={'Advanced Usage'} style={{padding: 0}}/>
             </Nav.Item>
           </Nav>
         </div>
@@ -51,7 +51,6 @@ const GettingStarted = () => {
 
       </div>
     </div>
-    // <VerticalExpander style={{}} header={<div><h1>GUI 4 Comby</h1><h2>Tag line</h2></div>}>Getting Started</VerticalExpander>
   )
 }
 export default GettingStarted;

--- a/src/components/GettingStarted/GettingStarted.tsx
+++ b/src/components/GettingStarted/GettingStarted.tsx
@@ -1,0 +1,57 @@
+import VerticalExpander from "../VerticalExpander/verticalExpander";
+import {useRecoilValue} from "recoil";
+import {mainSizeAtom} from "../../App.recoil";
+import './GettingStarted.css';
+import NewTabButton from "../NewTabButton/NewTabButton";
+import {TabType} from "../TabIcon/TabIcon";
+import {Nav, Navbar} from "react-bootstrap";
+
+const GettingStarted = () => {
+  const mainSizeState = useRecoilValue(mainSizeAtom);
+  console.log('mainSizeState.rect!.height', mainSizeState.rect!.height);
+
+  return (
+    <div className='cover' style={{
+      minBlockSize: `${mainSizeState.rect!.height}px`,
+    }}>
+      <div className={'hero'} style={{margin: 'auto'}}>
+        <h2>GUI 4 Comby</h2>
+        <h3>Find & Refactor made easy</h3>
+        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+          <Nav style={{marginRight: '1em'}} className={'flex-column'}>
+            <Navbar.Brand><strong>Start</strong></Navbar.Brand>
+            <Nav.Item>
+              <NewTabButton type={TabType.Playground} text={'Playground'} style={{padding: 0}}/>
+            </Nav.Item>
+            <Nav.Item>
+              <NewTabButton type={TabType.Filesystem} text={'Filesystem Find & Replace'} style={{padding: 0}}/>
+            </Nav.Item>
+          </Nav>
+          <Nav className={'flex-column'}>
+            <Navbar.Brand><strong>Learn</strong></Navbar.Brand>
+            <Nav.Item>
+              <NewTabButton type={TabType.Docs} text={'Overview'} style={{padding: 0}}/>
+            </Nav.Item>
+            <Nav.Item>
+              <NewTabButton type={TabType.Docs} text={'Basic Usage'} style={{padding: 0}}/>
+            </Nav.Item>
+            <Nav.Item>
+              <NewTabButton type={TabType.Docs} text={'Advanced Usage'} style={{padding: 0}}/>
+            </Nav.Item>
+          </Nav>
+        </div>
+      </div>
+      <div>
+        <Nav style={{display: 'flex', alignItems: 'center', margin: 'auto', justifyContent: 'center'}}>
+          <Navbar.Brand>A desktop app for</Navbar.Brand>
+          <Nav.Item><Nav.Link href={'https://comby.dev/'} target={'_blank'}>comby.dev</Nav.Link></Nav.Item>
+          <Navbar.Brand>modeled after</Navbar.Brand>
+          <Nav.Item><Nav.Link href={'https://comby.live/'} target={'_blank'}>comby.live</Nav.Link></Nav.Item>
+        </Nav>
+
+      </div>
+    </div>
+    // <VerticalExpander style={{}} header={<div><h1>GUI 4 Comby</h1><h2>Tag line</h2></div>}>Getting Started</VerticalExpander>
+  )
+}
+export default GettingStarted;

--- a/src/components/GettingStarted/GettingStarted.tsx
+++ b/src/components/GettingStarted/GettingStarted.tsx
@@ -1,4 +1,3 @@
-import VerticalExpander from "../VerticalExpander/verticalExpander";
 import {useRecoilValue} from "recoil";
 import {mainSizeAtom} from "../../App.recoil";
 import './GettingStarted.css';

--- a/src/components/NewTabButton/NewDocTabButton.tsx
+++ b/src/components/NewTabButton/NewDocTabButton.tsx
@@ -1,0 +1,36 @@
+import {Nav} from "react-bootstrap";
+import TabIcon, {TabType} from "../TabIcon/TabIcon";
+import {useRecoilState} from "recoil";
+import {getId, tabsState} from "../../App.recoil";
+import {useNavigate} from "react-router-dom";
+import {CSSProperties} from "react";
+
+type Props = {
+  text?: string;
+  style?: CSSProperties;
+  docId?: string;
+  hash?: string;
+}
+const NewDocTabButton = ({text, style, docId, hash}:Props) => {
+  const [tabs, setTabs] = useRecoilState(tabsState);
+  const navigate = useNavigate();
+  const title = 'Docs';
+  const segment='docs';
+
+
+  function add() {
+    const id = getId();
+    const path = `/${segment}/${id}${docId ? `/${docId}` : ''}${hash ? `#${hash}`: ''}`;
+
+    setTabs((oldState) => [
+      ...oldState,
+      {id, type: TabType.Docs, title, path}
+    ]);
+    navigate(path);
+  }
+
+  return (
+    <Nav.Link className={'button'} onClick={add} style={style}><TabIcon type={TabType.Docs}/>{text ? ` ${text}` : null}</Nav.Link>
+  )
+}
+export default NewDocTabButton;

--- a/src/components/NewTabButton/NewTabButton.tsx
+++ b/src/components/NewTabButton/NewTabButton.tsx
@@ -3,11 +3,14 @@ import TabIcon, {TabType} from "../TabIcon/TabIcon";
 import {useRecoilState} from "recoil";
 import {getId, tabsState} from "../../App.recoil";
 import {useNavigate} from "react-router-dom";
+import {CSSProperties} from "react";
 
 type Props = {
   type: TabType;
+  text?: string;
+  style?: CSSProperties;
 }
-const NewTabButton = ({type}:Props) => {
+const NewTabButton = ({type, text, style}:Props) => {
   const [tabs, setTabs] = useRecoilState(tabsState);
   const navigate = useNavigate();
 
@@ -31,7 +34,7 @@ const NewTabButton = ({type}:Props) => {
   }
 
   return (
-    <Nav.Link className={'button'} onClick={add}><TabIcon type={type}/></Nav.Link>
+    <Nav.Link className={'button'} onClick={add} style={style}><TabIcon type={type}/>{text ? ` ${text}` : null}</Nav.Link>
   )
 }
 export default NewTabButton;

--- a/src/components/TabContent/TabContent.tsx
+++ b/src/components/TabContent/TabContent.tsx
@@ -7,6 +7,7 @@ import {useParams} from "react-router-dom";
 import {useRecoilValue} from "recoil";
 import {tabsState} from "../../App.recoil";
 import Docs from "../Docs/Docs";
+import GettingStarted from "../GettingStarted/GettingStarted";
 
 type Props = {
 
@@ -26,7 +27,7 @@ const TabContent = ({}:Props) => {
 
   let Component  = <div>Todo</div>;
   switch(tab.type){
-    case TabType.Index: Component = <div>Getting Started Placeholder <Greeter/></div>; break;
+    case TabType.Index: Component = <GettingStarted/>; break;
     case TabType.Playground: Component = <Playground id={params.tabId!}/>; break;
     case TabType.Filesystem: Component = <div>Filesystem Placeholder</div>; break;
     case TabType.Docs: Component = <Docs/>; break;


### PR DESCRIPTION
Replaces the current getting started placeholder (tauri app greeter component) w/ an actual getting started splash page.

## Todo
- [x] Learn links should open doc tab showing content of specific page